### PR TITLE
Return exit code properly

### DIFF
--- a/src/LaravelDeployer/Commands/BaseCommand.php
+++ b/src/LaravelDeployer/Commands/BaseCommand.php
@@ -55,7 +55,7 @@ class BaseCommand extends Command
 
         $parameters = $this->getParametersAsString($this->parameters);
         $depBinary = 'vendor' . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'dep';
-        $this->process("$depBinary --file=$deployFile $command $parameters");
+        return $this->process("$depBinary --file=$deployFile $command $parameters");
     }
 
     public function getDeployFile()
@@ -100,7 +100,7 @@ class BaseCommand extends Command
 
     public function process($command)
     {
-        $process = (new Process($command))
+        return (new Process($command))
             ->setTty($this->isTtySupported())
             ->setWorkingDirectory(base_path())
             ->setTimeout(null)

--- a/src/LaravelDeployer/Commands/Deploy.php
+++ b/src/LaravelDeployer/Commands/Deploy.php
@@ -9,6 +9,6 @@ class Deploy extends BaseCommand
 
     public function handle()
     {
-        $this->dep('deploy');
+        return $this->dep('deploy');
     }
 }

--- a/src/LaravelDeployer/Commands/DeployConfigs.php
+++ b/src/LaravelDeployer/Commands/DeployConfigs.php
@@ -9,6 +9,6 @@ class DeployConfigs extends BaseCommand
 
     public function handle()
     {
-        $this->dep('config:dump');
+        return $this->dep('config:dump');
     }
 }

--- a/src/LaravelDeployer/Commands/DeployCurrent.php
+++ b/src/LaravelDeployer/Commands/DeployCurrent.php
@@ -9,6 +9,6 @@ class DeployCurrent extends BaseCommand
 
     public function handle()
     {
-        $this->dep('config:current');
+        return $this->dep('config:current');
     }
 }

--- a/src/LaravelDeployer/Commands/DeployDump.php
+++ b/src/LaravelDeployer/Commands/DeployDump.php
@@ -9,6 +9,6 @@ class DeployDump extends BaseCommand
 
     public function handle()
     {
-        $this->dep('debug:task');
+        return $this->dep('debug:task');
     }
 }

--- a/src/LaravelDeployer/Commands/DeployHosts.php
+++ b/src/LaravelDeployer/Commands/DeployHosts.php
@@ -9,6 +9,6 @@ class DeployHosts extends BaseCommand
 
     public function handle()
     {
-        $this->dep('config:hosts');
+        return $this->dep('config:hosts');
     }
 }

--- a/src/LaravelDeployer/Commands/DeployList.php
+++ b/src/LaravelDeployer/Commands/DeployList.php
@@ -14,6 +14,6 @@ class DeployList extends BaseCommand
 
     public function handle()
     {
-        $this->dep('list');
+        return $this->dep('list');
     }
 }

--- a/src/LaravelDeployer/Commands/DeployRollback.php
+++ b/src/LaravelDeployer/Commands/DeployRollback.php
@@ -9,6 +9,6 @@ class DeployRollback extends BaseCommand
 
     public function handle()
     {
-        $this->dep('rollback');
+        return $this->dep('rollback');
     }
 }

--- a/src/LaravelDeployer/Commands/DeployRun.php
+++ b/src/LaravelDeployer/Commands/DeployRun.php
@@ -10,6 +10,6 @@ class DeployRun extends BaseCommand
     public function handle()
     {
         // Task will be executed as a direct command of `dep`.
-        $this->dep('');
+        return $this->dep('');
     }
 }

--- a/src/LaravelDeployer/Commands/Logs.php
+++ b/src/LaravelDeployer/Commands/Logs.php
@@ -9,6 +9,6 @@ class Logs extends BaseCommand
 
     public function handle()
     {
-        $this->dep('logs');
+        return $this->dep('logs');
     }
 }

--- a/src/LaravelDeployer/Commands/Ssh.php
+++ b/src/LaravelDeployer/Commands/Ssh.php
@@ -9,6 +9,6 @@ class Ssh extends BaseCommand
 
     public function handle()
     {
-        $this->dep('ssh');
+        return $this->dep('ssh');
     }
 }


### PR DESCRIPTION
Now you can use the `deploy` commands in CI pipelines and have the jobs exit properly.