### PR TITLE
Fix for #52 `Task yarn:install not found`

### DIFF
--- a/src/recipe/laravel-deployer.php
+++ b/src/recipe/laravel-deployer.php
@@ -24,6 +24,7 @@ require 'task/fpm.php';
 require 'task/hook.php';
 require 'task/logs.php';
 require 'task/npm.php';
+require 'task/yarn.php';
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
During the deployment I came across a problem: `Task yarn:install not found`
In addition to the other changes, I forgot to specify a link to task.