### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto
+
+/.gitignore export-ignore
+/phpunit.xml export-ignore
+/tests export-ignore
+/.gitattributes export-ignore


### PR DESCRIPTION
Consider adding `.gitattributes` so the users don't include the tests for laravel-deployer in their `vendor/` files.