### PR TITLE
Add support for Laravel Telescope

### DIFF
--- a/docs/all-tasks.md
+++ b/docs/all-tasks.md
@@ -33,6 +33,8 @@ php artisan deploy:list namespace  # List all tasks starting with `namespace:`
 | `artisan:storage:link`      | Execute artisan storage:link |
 | `artisan:up`                | Disable maintenance mode |
 | `artisan:view:clear`        | Execute artisan view:clear |
+| `artisan:telescope:clear`   | Execute artisan telescope:clear |
+| `artisan:telescope:prune`   | Execute artisan telescope:prune |
 | `config:current`            | Show current paths |
 | `config:dump`               | Print host configuration |
 | `config:hosts`              | Print all hosts |

--- a/docs/how-to-telescope.md
+++ b/docs/how-to-telescope.md
@@ -1,0 +1,36 @@
+# How to clear Telescope entries?
+
+If you are using Laravel's Telescope, you might want to clean up Telescope's entry table as data can get accumulated quickly.
+
+Telescope includes two console commands to clean up the entries table: 
+- `telescope:clean`: this will delete all entries
+- `telescope:prune`: this will clear all entries up until a given date/time. By default Telescope will retain entries made in the last 48 hours.
+
+When deploying to a Production environment, you typically don't need to enable Telescope. However, if you use a testing or staging environment for example, you may want to clean the Telescope data with a deployment.
+
+You can use the `artisan:telescope:prune` to prune Telescope data with the following configuration:
+
+```php
+// config/deploy.php
+    
+'hooks' => [
+    'ready' => [
+        // ...
+        'artisan:telescope:prune',
+    ],
+],
+```
+
+If you don't need to keep the entries of the last 48 hours, you can use the `artisan:telescope:clear` to entirely clear Telescope's entry table like this:
+
+```php
+// config/deploy.php
+    
+'hooks' => [
+    'ready' => [
+        // ...
+        'artisan:telescope:clear',
+    ],
+],
+```
+

--- a/src/LaravelDeployer/Commands/DeployInit.php
+++ b/src/LaravelDeployer/Commands/DeployInit.php
@@ -71,6 +71,7 @@ class DeployInit extends BaseCommand
         $this->builder->add('hooks.build', 'npm:production');
         $this->builder->add('hooks.ready', 'artisan:migrate');
         $this->builder->add('hooks.ready', 'artisan:horizon:terminate');
+        $this->builder->add('hooks.ready', 'artisan:telescope:prune');
     }
 
     public function welcomeMessage($emoji, $message)
@@ -163,5 +164,20 @@ class DeployInit extends BaseCommand
         if ($this->confirm('Do you want to terminate horizon after each deployment?')) {
             $this->builder->add('hooks.ready', 'artisan:horizon:terminate');
         }
+
+        $telescope = $this->choice(
+            'Do you want to clear telescope entries after each deployment?',
+            [
+                'No',
+                'Yes all entries',
+                'Yes stale entries only',
+            ], 0
+        );
+
+        if ($telescope !== 'No') {
+            $command = $telescope === 'Yes all entries' ? 'clear' : 'prune';
+            $this->builder->add('hooks.ready', "artisan.telescope:$command");
+        }
+
     }
 }

--- a/src/LaravelDeployer/Commands/DeployInit.php
+++ b/src/LaravelDeployer/Commands/DeployInit.php
@@ -71,7 +71,6 @@ class DeployInit extends BaseCommand
         $this->builder->add('hooks.build', 'npm:production');
         $this->builder->add('hooks.ready', 'artisan:migrate');
         $this->builder->add('hooks.ready', 'artisan:horizon:terminate');
-        $this->builder->add('hooks.ready', 'artisan:telescope:prune');
     }
 
     public function welcomeMessage($emoji, $message)
@@ -163,20 +162,6 @@ class DeployInit extends BaseCommand
 
         if ($this->confirm('Do you want to terminate horizon after each deployment?')) {
             $this->builder->add('hooks.ready', 'artisan:horizon:terminate');
-        }
-
-        $telescope = $this->choice(
-            'Do you want to clear telescope entries after each deployment?',
-            [
-                'No',
-                'Yes all entries',
-                'Yes stale entries only',
-            ], 0
-        );
-
-        if ($telescope !== 'No') {
-            $command = $telescope === 'Yes all entries' ? 'clear' : 'prune';
-            $this->builder->add('hooks.ready', "artisan.telescope:$command");
         }
 
     }

--- a/src/task/artisan.php
+++ b/src/task/artisan.php
@@ -46,3 +46,9 @@ task('artisan:storage:link', artisan('storage:link', ['min' => 5.3]));
 
 desc('Execute artisan horizon:terminate');
 task('artisan:horizon:terminate', artisan('horizon:terminate'));
+
+desc('Execute artisan telescope:clear');
+task('artisan:telescope:clear', artisan('telescope:clear'));
+
+desc('Execute artisan telescope:prune');
+task('artisan:telescope:prune', artisan('telescope:prune'));

--- a/tests/Features/DeployInitTest.php
+++ b/tests/Features/DeployInitTest.php
@@ -80,6 +80,7 @@ class DeployInitTest extends DeploymentTestCase
                     "artisan:config:cache",
                     "artisan:migrate",
                     "artisan:horizon:terminate",
+                    "artisan:telescope:prune",
                 ],
                 "done" => [
                     'fpm:reload',

--- a/tests/Features/DeployInitTest.php
+++ b/tests/Features/DeployInitTest.php
@@ -80,7 +80,6 @@ class DeployInitTest extends DeploymentTestCase
                     "artisan:config:cache",
                     "artisan:migrate",
                     "artisan:horizon:terminate",
-                    "artisan:telescope:prune",
                 ],
                 "done" => [
                     'fpm:reload',

--- a/tests/Features/DeployListTest.php
+++ b/tests/Features/DeployListTest.php
@@ -40,6 +40,8 @@ class DeployListTest extends DeploymentTestCase
         $this->assertContains('artisan:storage:link', $output);
         $this->assertContains('artisan:up', $output);
         $this->assertContains('artisan:view:clear', $output);
+        $this->assertContains('artisan:telescope:clear', $output);
+        $this->assertContains('artisan:telescope:prune', $output);
 
         // Config
         $this->assertContains('config:current', $output);

--- a/tests/Unit/ConfigFileBuilderTest.php
+++ b/tests/Unit/ConfigFileBuilderTest.php
@@ -212,4 +212,46 @@ class ConfigFileBuilderTest extends TestCase
 
         $this->assertEquals('some/repository.git', $repo);
     }
+
+    /** @test */
+    function it_can_be_set_to_clear_telescope_entries()
+    {
+        $config = (new ConfigFileBuilder)
+            ->add('hooks.ready', 'artisan:telescope:clear')
+            ->build();
+
+        $this->assertArraySubset(
+            ['hooks' => [
+                'ready' => [
+                    'artisan:storage:link',
+                    'artisan:view:clear',
+                    'artisan:cache:clear',
+                    'artisan:config:cache',
+                    'artisan:telescope:clear',
+                ],
+            ]],
+            $config->toArray()
+        );
+    }
+
+    /** @test */
+    function it_can_be_set_to_prune_telescope_entries()
+    {
+        $config = (new ConfigFileBuilder)
+            ->add('hooks.ready', 'artisan:telescope:prune')
+            ->build();
+
+        $this->assertArraySubset(
+            ['hooks' => [
+                'ready' => [
+                    'artisan:storage:link',
+                    'artisan:view:clear',
+                    'artisan:cache:clear',
+                    'artisan:config:cache',
+                    'artisan:telescope:prune',
+                ],
+            ]],
+            $config->toArray()
+        );
+    }
 }


### PR DESCRIPTION
This PR adds support for Laravel's Telescope commands `telescope:prune` and `telescope:clear`. 
I've added an 'how-to' in the documentations section how it can be used.

Cheers! Sacha