### PR TITLE
Updated composer.json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,0 @@
-* text=auto
-
-/.gitignore export-ignore
-/phpunit.xml export-ignore
-/tests export-ignore
-/.gitattributes export-ignore

--- a/composer.json
+++ b/composer.json
@@ -41,5 +41,13 @@
                 "Lorisleiva\\LaravelDeployer\\LaravelDeployerServiceProvider"
             ]
         }
+    },
+    "archive": {
+        "exclude": [
+            "/docs",
+            "/tests",
+            "/composer.lock",
+            "/phpunit.xml"
+        ]
     }
 }


### PR DESCRIPTION
This fix #81..
As suggested in #79, it exclude tests files and other files that are irrelevant on production environment..

But this PR use composer [archive](https://getcomposer.org/doc/04-schema.md#archive) build-in function, and not use .gitattributes (which is 4 years old).

Using composer function have the pro that the exclusion is limited to the use of composer and does not impact the use of `git archive` command, which is used by github (and others) to create release zip..

Try to download [latest release](https://github.com/lorisleiva/laravel-deployer/archive/v0.2.8.zip), in source code archive all files excluded by .gitattributes are missing..
But (IMHO) github's release should contains **ALL** repo files, and not just some..
If anyone want to use the package without using git (so without `git clone`), is unabled to do so with .gitattributes solution..

Using composer archive function do not change anything related to `git archive` command, but when using `composer require lorisleiva/laravel-deployer` prevents the addition of the specified excluded files..