### PR TITLE
Change optimize:clean to optimize:clear

### DIFF
--- a/docs/all-tasks.md
+++ b/docs/all-tasks.md
@@ -31,7 +31,7 @@ php artisan deploy:list namespace  # List all tasks starting with `namespace:`
 | `artisan:migrate:rollback`  | Execute artisan migrate:rollback |
 | `artisan:migrate:status`    | Execute artisan migrate:status |
 | `artisan:optimize`          | Execute artisan optimize |
-| `artisan:optimize:clean`    | Execute artisan optimize:clean |
+| `artisan:optimize:clear`    | Execute artisan optimize:clear |
 | `artisan:queue:restart`     | Execute artisan queue:restart |
 | `artisan:route:cache`       | Execute artisan route:cache |
 | `artisan:storage:link`      | Execute artisan storage:link |

--- a/src/task/artisan.php
+++ b/src/task/artisan.php
@@ -44,8 +44,8 @@ task('artisan:view:cache', artisan('view:cache', ['min' => 5.6]));
 desc('Execute artisan optimize');
 task('artisan:optimize', artisan('optimize', ['min' => 5.7]));
 
-desc('Execute artisan optimize:clean');
-task('artisan:optimize:clean', artisan('optimize:clean', ['min' => 5.7]));
+desc('Execute artisan optimize:clear');
+task('artisan:optimize:clear', artisan('optimize:clear', ['min' => 5.7]));
 
 desc('Execute artisan queue:restart');
 task('artisan:queue:restart', artisan('queue:restart'));

--- a/tests/Features/DeployListTest.php
+++ b/tests/Features/DeployListTest.php
@@ -36,7 +36,7 @@ class DeployListTest extends DeploymentTestCase
         $this->assertStringContainsString('artisan:migrate:rollback', $output);
         $this->assertStringContainsString('artisan:migrate:status', $output);
         $this->assertStringContainsString('artisan:optimize', $output);
-        $this->assertStringContainsString('artisan:optimize:clean', $output);
+        $this->assertStringContainsString('artisan:optimize:clear', $output);
         $this->assertStringContainsString('artisan:queue:restart', $output);
         $this->assertStringContainsString('artisan:route:cache', $output);
         $this->assertStringContainsString('artisan:storage:link', $output);

--- a/tests/fixtures/recipes/mocks.php
+++ b/tests/fixtures/recipes/mocks.php
@@ -25,7 +25,7 @@ task('artisan:event:clear', function() {});
 task('artisan:event:cache', function() {});
 task('artisan:config:cache', function() {});
 task('artisan:optimize', function() {});
-task('artisan:optimize:clean', function() {});
+task('artisan:optimize:clear', function() {});
 
 // Mock public info task
 task('deploy:info_debug', ['deploy:info']);


### PR DESCRIPTION
This PR fixes a typo in the newly added command. It's called `clear`, not `clean`.