### PR TITLE
Add new tasks for Horizon and Telescope

### DIFF
--- a/src/task/artisan.php
+++ b/src/task/artisan.php
@@ -53,8 +53,14 @@ task('artisan:queue:restart', artisan('queue:restart'));
 desc('Execute artisan storage:link');
 task('artisan:storage:link', artisan('storage:link', ['min' => 5.3]));
 
+desc('Execute artisan horizon:assets');
+task('artisan:horizon:assets', artisan('horizon:assets'));
+
 desc('Execute artisan horizon:terminate');
 task('artisan:horizon:terminate', artisan('horizon:terminate'));
+
+desc('Execute artisan telescope:publish');
+task('artisan:telescope:publish', artisan('telescope:publish'));
 
 desc('Execute artisan telescope:clear');
 task('artisan:telescope:clear', artisan('telescope:clear'));


### PR DESCRIPTION
I've added `artisan:horizon:assets` and `artisan:telescope:publish` because if you use this package, which is gorgeous by the way, in an environment that has auto-deploy with continuous integration you will end up having the `public/vendor` directory empty thus breaking those two services

**NOTE** neither of the commands force the overwrite so this is a safe execution.