### PR TITLE
Update horizon task

### DIFF
--- a/src/task/artisan.php
+++ b/src/task/artisan.php
@@ -56,6 +56,9 @@ task('artisan:storage:link', artisan('storage:link', ['min' => 5.3]));
 desc('Execute artisan horizon:assets');
 task('artisan:horizon:assets', artisan('horizon:assets'));
 
+desc('Execute artisan horizon:publish');
+task('artisan:horizon:publish', artisan('horizon:publish'));
+
 desc('Execute artisan horizon:terminate');
 task('artisan:horizon:terminate', artisan('horizon:terminate'));
 


### PR DESCRIPTION
The new version of Horizon (v4+) doesn't rely on `horizon:assets` anymore but instead they have changed the command to `horizon:publish` to stay in sync with Telescope and Nova commands.

I've added a new task just for that while keeping the old `horizon:assets` for backward compatibility.

This is not a breaking change PR.


ps: your youtube spa serie is lit 🔥