### PR TITLE
Fix tty supported method

### DIFF
--- a/src/LaravelDeployer/Commands/BaseCommand.php
+++ b/src/LaravelDeployer/Commands/BaseCommand.php
@@ -121,7 +121,7 @@ class BaseCommand extends Command
 
     public function isTtySupported()
     {
-        return ! env('APP_ENV') === 'testing'
+        return ! (env('APP_ENV') === 'testing')
             && Process::isTtySupported();
     }
 }


### PR DESCRIPTION
After upgrading to Laravel 7 I received the following error:
`Pseudo-terminal will not be allocated because stdin is not a terminal.`

turns out its caused from here https://github.com/lorisleiva/laravel-deployer/commit/20658cc432278325ab9f1ed14464e3cb57125e0a#diff-a062ee77a3ef1c08ca1f75de52cacbf5R116
and `! env('APP_ENV') === 'testing'` returns `false` in none testing environment.
