### PR TITLE
Add once() to migrate as done in upstream tasks

### DIFF
--- a/src/task/artisan.php
+++ b/src/task/artisan.php
@@ -9,7 +9,7 @@ desc('Enable maintenance mode');
 task('artisan:down', artisan('down', ['runInCurrent', 'showOutput']));
 
 desc('Execute artisan migrate');
-task('artisan:migrate', artisan('migrate --force', ['skipIfNoEnv']));
+task('artisan:migrate', artisan('migrate --force', ['skipIfNoEnv']))->once();
 
 desc('Execute artisan migrate:fresh');
 task('artisan:migrate:fresh', artisan('migrate:fresh --force'));


### PR DESCRIPTION
Noticing that the overridden `artisan:migrate` command is missing the upstream change to only have it run on the first server.

Was added in c1309f255fc6756c70c42465f76e3d08cbeebc7a

And re-added in https://github.com/deployphp/deployer/pull/2169